### PR TITLE
vp8/util/memory.cc: include correct header

### DIFF
--- a/src/vp8/util/memory.cc
+++ b/src/vp8/util/memory.cc
@@ -1,4 +1,4 @@
-#include <emmintrin.h>
+#include <immintrin.h>
 #include "options.hh"
 #include "memory.hh"
 #ifdef _WIN32


### PR DESCRIPTION
immintrin.h must be included when compiling with AVX2 support.

Note that immintrin.h includes other SSE-related headers such as
emmintrin.h as well.