### PR TITLE
Add install target for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,3 +211,5 @@ ADD_CUSTOM_TARGET(
 )
 
 ADD_DEPENDENCIES(lepton version)
+
+install (TARGETS lepton lepton-avx DESTINATION bin)


### PR DESCRIPTION
This way we can use `make install` when building with CMake (with the ability to customize prefix, DESTDIR, etc., of course).

P.S. Yes, CLA signed.