### PR TITLE
Tweak Python prints to function identically in 2/3

### DIFF
--- a/test_suite/forktester.py
+++ b/test_suite/forktester.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function, division
 import subprocess
 import sys
 import threading
@@ -31,30 +32,30 @@ with open(jpg_name, 'rb') as f:
     jpg = f.read()
 def fn():
     valid_fds[0][0].write(jpg)
-    print ('written ',valid_fds[0][0])
+    print('written ', valid_fds[0][0])
     valid_fds[0][0].close()
-    print ('closed')
+    print('closed')
 def fn1():
     valid_fds[1][0].write(dat)
-    print ('written ',valid_fds[1][0])
+    print('written ', valid_fds[1][0])
     valid_fds[1][0].close()
-    print ('xclosed ',valid_fds[1][0])
-u=threading.Thread(target=add4)
+    print('xclosed ', valid_fds[1][0])
+u = threading.Thread(target=add4)
 u.start()
-t=threading.Thread(target=fn)
+t = threading.Thread(target=fn)
 t.start()
 
 dat = valid_fds[0][1].read()
 valid_fds[0][1].close()
 t.join()
-print (len(jpg),len(dat))
-v=threading.Thread(target=fn1)
+print(len(jpg), len(dat))
+v = threading.Thread(target=fn1)
 v.start()
 ojpg = valid_fds[1][1].read()
 valid_fds[1][1].close()
 t.join()
 
-assert (ojpg == jpg)
+assert ojpg == jpg
 
-print ('yay',len(ojpg),len(dat),len(dat)/float(len(ojpg)))
+print('yay', len(ojpg), len(dat), len(dat) / len(ojpg))
 u.join()

--- a/test_suite/sockettester.py
+++ b/test_suite/sockettester.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 import subprocess
 import sys
 import threading
@@ -85,8 +86,8 @@ def test_compression(binary_name, socket_name = None, too_short_time_bound=False
     lepton_socket.close()
     t.join()
     
-    print ('encode time ',encode_end - encode_start)
-    print (len(jpg),len(dat))
+    print('encode time ', encode_end - encode_start)
+    print(len(jpg), len(dat))
 
     while True:
         v=threading.Thread(target=decoder)
@@ -103,14 +104,14 @@ def test_compression(binary_name, socket_name = None, too_short_time_bound=False
         v.join()
         if is_zlib:
             ojpg = zlib.decompress(ojpg)
-        print (len(ojpg))
-        print (len(jpg))
+        print(len(ojpg))
+        print(len(jpg))
         assert (ojpg == jpg)
-        print ('decode time ',decode_end - decode_start, '(', decode_mid-decode_start,')')
+        print('decode time ', decode_end - decode_start, '(', decode_mid - decode_start,')')
         if not parsed_args.benchmark:
             break
         
-    print ('yay',len(ojpg),len(dat),len(dat)/float(len(ojpg)), 'parent pid is ',proc.pid)
+    print('yay', len(ojpg), len(dat), len(dat) / float(len(ojpg)), 'parent pid is ', proc.pid)
 
     proc.terminate()
     proc.wait()
@@ -133,12 +134,10 @@ if not parsed_args.benchmark:
     test_compression('./lepton', '/tmp/' + str(uuid.uuid4()))
     test_compression('./lepton', '/tmp/' + str(uuid.uuid4()), is_zlib=True)
 
-
-    ok = False
     try:
         test_compression('./lepton', '/tmp/' + str(uuid.uuid4()), True)
     except (AssertionError, EnvironmentError):
-        ok = True
-    finally:
-        assert (ok and "the time bound must stop the process")
-    print ("SUCCESS DONE")
+        pass
+    else:
+        raise AssertionError("the time bound must stop the process")
+    print("SUCCESS DONE")

--- a/test_suite/sockettester.py
+++ b/test_suite/sockettester.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+from __future__ import print_function, division
 import subprocess
 import sys
 import threading
@@ -11,16 +11,12 @@ import argparse
 import zlib
 base_dir = os.path.dirname(sys.argv[0])
 parser = argparse.ArgumentParser(description='Benchmark and test socket server for compression')
-parser.add_argument('files', metavar='N', type=str, nargs='*', default=[os.path.join(base_dir,
-                                                                                     "..", "images", "iphone.jpg")])
-parser.add_argument('--benchmark', dest='benchmark', action='store_true')
-parser.add_argument('--bench', dest='benchmark', action='store_true')
-parser.add_argument('-benchmark', dest='benchmark', action='store_true')
-parser.add_argument('-bench', dest='benchmark', action='store_true')
-parser.add_argument('--singlethread', dest='singlethread', action='store_true')
-parser.add_argument('-singlethread', dest='singlethread', action='store_true')
-parser.set_defaults(benchmark=False)
-parser.set_defaults(singlethread=False)
+parser.add_argument('files', metavar='N', type=str, nargs='*',
+                    default=[os.path.join(base_dir, "..", "images", "iphone.jpg")])
+parser.add_argument('--bench', '--benchmark', '-bench', '-benchmark',
+                    dest='benchmark', action='store_true')
+parser.add_argument('--singlethread', '-singlethread',
+                    dest='singlethread', action='store_true')
 parsed_args = parser.parse_args()
 jpg_name = parsed_args.files[0]
 
@@ -35,7 +31,7 @@ def read_all_sock(sock):
             pass
     return b''.join(datas)
 
-def test_compression(binary_name, socket_name = None, too_short_time_bound=False, is_zlib=False):
+def test_compression(binary_name, socket_name=None, too_short_time_bound=False, is_zlib=False):
     global jpg_name
     custom_name = socket_name is not None
     xargs = [binary_name,
@@ -57,7 +53,7 @@ def test_compression(binary_name, socket_name = None, too_short_time_bound=False
                             stdin=subprocess.PIPE)
         duplicate_socket_name = b''
         duplicate_socket_name = dup_proc.stdout.readline().strip()
-        assert (not duplicate_socket_name)
+        assert not duplicate_socket_name
     if is_zlib:
         socket_name = socket_name.replace(b'.uport', b'') + b'.z0'
     with open(jpg_name, 'rb') as f:
@@ -75,7 +71,7 @@ def test_compression(binary_name, socket_name = None, too_short_time_bound=False
         except EnvironmentError:
             pass
 
-    t=threading.Thread(target=encoder)
+    t = threading.Thread(target=encoder)
 
     encode_start = time.time()
     lepton_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -85,12 +81,12 @@ def test_compression(binary_name, socket_name = None, too_short_time_bound=False
     encode_end = time.time()
     lepton_socket.close()
     t.join()
-    
+
     print('encode time ', encode_end - encode_start)
     print(len(jpg), len(dat))
 
     while True:
-        v=threading.Thread(target=decoder)
+        v = threading.Thread(target=decoder)
 
         decode_start = time.time()
         lepton_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -106,16 +102,16 @@ def test_compression(binary_name, socket_name = None, too_short_time_bound=False
             ojpg = zlib.decompress(ojpg)
         print(len(ojpg))
         print(len(jpg))
-        assert (ojpg == jpg)
+        assert ojpg == jpg
         print('decode time ', decode_end - decode_start, '(', decode_mid - decode_start,')')
         if not parsed_args.benchmark:
             break
-        
-    print('yay', len(ojpg), len(dat), len(dat) / float(len(ojpg)), 'parent pid is ', proc.pid)
+
+    print('yay', len(ojpg), len(dat), len(dat) / len(ojpg), 'parent pid is ', proc.pid)
 
     proc.terminate()
     proc.wait()
-    assert (not os.path.exists(socket_name))
+    assert not os.path.exists(socket_name)
 
 has_avx2 = False
 try:


### PR DESCRIPTION
Wrapping `print`'s in parens has different behavior between Python 2, 3. While fixed previously, added a `from __future__ import print_function` and some other stuff so they should perform identically between the two.

Also some whitespace fixes, redundant arguments condensed (same functionality)...might be a bit of bikeshedding, I dunno.
