### PR TITLE
close opened file descriptors properly

### DIFF
--- a/src/lepton/jpgcoder.cc
+++ b/src/lepton/jpgcoder.cc
@@ -1270,6 +1270,7 @@ std::string uniq_filename(std::string filename) {
         filename += "_";
         fp = fopen(filename.c_str(), "rb");
     }
+    fclose(fp);
     return filename;
 }
 


### PR DESCRIPTION
[[src/lepton/jpgcoder.cc:1273](https://github.com/dropbox/lepton/blob/master/src/lepton/jpgcoder.cc#L1273)]: `(error) Resource leak: fp`

Calling `fclose()` will ensure the file descriptor is properly disposed of and output buffers flushed so the data written to the file will be present in the file on disk.

Found by https://github.com/bryongloden/cppcheck