### PR TITLE
Revert "close opened file descriptors properly"

### DIFF
--- a/src/lepton/jpgcoder.cc
+++ b/src/lepton/jpgcoder.cc
@@ -1270,7 +1270,6 @@ std::string uniq_filename(std::string filename) {
         filename += "_";
         fp = fopen(filename.c_str(), "rb");
     }
-    fclose(fp);
     return filename;
 }
 


### PR DESCRIPTION
Reverts dropbox/lepton#60

Added `fclose` causes SIGSEGV on some OS, because `fp`, which is arg for `fclose`, in this context always is NULL.