### PR TITLE
resource leak: fp

### DIFF
--- a/src/vp8/model/model.cc
+++ b/src/vp8/model/model.cc
@@ -397,6 +397,7 @@ void load_model(Model&model, const char * filename) {
     FILE * fp = fopen(filename, "rb");
     if (fp) {
         const size_t expected_size = fread(&model, 1, sizeof(model), fp);
+        fclose(fp);
         (void)expected_size;
         always_assert(sizeof(model) == expected_size && "unexpected model file size.");
     } else {


### PR DESCRIPTION
With reference to (WRT) @AlexanderFrolov and https://github.com/dropbox/lepton/pull/62, calling `fclose(fp)` here will ensure the file descriptor is properly disposed of and output buffers flushed so the data written to the file will be present in the file on disk. Furthermore, calling `fclose(fp)` with not cause a segmentation in some OS because `fp != NULL`.