### PR TITLE
Fix posix_memalign call

### DIFF
--- a/src/vp8/util/memory.cc
+++ b/src/vp8/util/memory.cc
@@ -58,7 +58,15 @@ void* custom_malloc (size_t size) {
 #ifdef _WIN32
     return _aligned_malloc(size, 32);
 #else
-    return posix_memalign(32, size);
+    void *ptr;
+    int retval = posix_memalign(&ptr, 32, size);
+    if (!g_use_seccomp) {
+        assert(retval == 0 && "posix_memalign returned non-zero");
+    }
+    if (retval != 0) {
+        custom_exit(ExitCode::MALLOCED_NULL);
+    }
+    return ptr;
 #endif
 #else
     void * retval = Sirikata::memmgr_alloc(size);


### PR DESCRIPTION
posix_memalign signature is:

`int posix_memalign(void **memptr, size_t alignment, size_t size);`

Updated the file to reflect this. `make` with `CXXFLAGS=-g -O2 -DUSE_STANDARD_MEMORY_ALLOCATORS` now succeeds (although actually using the tool with standard memory allocators is a different story...)