### PR TITLE
[jpgcoder.cc] fix undefined behavior

### DIFF
--- a/src/lepton/jpgcoder.cc
+++ b/src/lepton/jpgcoder.cc
@@ -2475,7 +2475,7 @@ bool decode_jpeg(const std::vector<std::pair<uint32_t, uint32_t> > & huff_input_
     int rstw; // restart wait counter
 
     int cmp, bpos, dpos;
-    int mcu, sub, csc;
+    int mcu = 0, sub, csc;
     int eob, sta;
     bool is_baseline = true;
     max_cmp = 0; // the maximum component in a truncated image


### PR DESCRIPTION
:bug: label: security

Greetings,

It's always good to initialize integer variables, at least to 0, because if we try to retrieve its value before it gets assigned any actual (non-garbage) value, then it results in undefined behavior, e.g. line number [2937](https://github.com/dropbox/lepton/blob/master/src/lepton/jpgcoder.cc#L2937) of [lepton/src/lepton/jpgcoder.cc](https://github.com/dropbox/lepton/blob/master/src/lepton/jpgcoder.cc).

REF: http://cwe.mitre.org/data/definitions/457.html

Signed-off-by: Bryon Gloden, CISSP® cissp@bryongloden.com