### PR TITLE
src/lepton/vp8_decoder.cc: PVS-Studio: bad initialization

### DIFF
--- a/src/lepton/vp8_decoder.cc
+++ b/src/lepton/vp8_decoder.cc
@@ -218,7 +218,7 @@ void VP8ComponentDecoder::initialize_thread_id(int thread_id, int target_thread_
         thread_state_[target_thread_state]->luma_splits_[0] = thread_handoff_[thread_id].luma_y_start;
         thread_state_[target_thread_state]->luma_splits_[1] = thread_handoff_[thread_id].luma_y_end;
     } else {
-        thread_state_[target_thread_state]->luma_splits_[0] = thread_handoff_.back().luma_y_end;
+        thread_state_[target_thread_state]->luma_splits_[0] = thread_handoff_.back().luma_y_start;
         thread_state_[target_thread_state]->luma_splits_[1] = thread_handoff_.back().luma_y_end;
     }
     //fprintf(stderr, "tid: %d   %d -> %d\n", thread_id, thread_state_[target_thread_state]->luma_splits_[0],


### PR DESCRIPTION
We have found and fixed a bug using PVS-Studio tool. PVS-Studio is a static code analyzer for C, C++ and C#: https://www.viva64.com/en/pvs-studio/

We suggests having a look at the emails, sent from @pvs-studio.com. 

Analyzer warning: V656 Variables are initialized through the call to the same function. It's probably an error or un-optimized code. Consider inspecting the 'thread_handoff_.back().luma_y_end' expression. Check lines: 221, 222. vp8_decoder.cc 222
