### PR TITLE
fix V796 from PVS-Studio

### DIFF
--- a/src/io/ZlibCompression.cc
+++ b/src/io/ZlibCompression.cc
@@ -234,6 +234,7 @@ ZlibDecoderCompressionWriter::ZlibDecoderCompressionWriter(DecoderWriter *w,
             break;
           case Z_STREAM_ERROR:
             always_assert(ret == Z_OK && "Specified integrity check but not supported");
+			break;
           default:
             always_assert(ret == Z_OK && "the stream decoder was not initialized properly");
         }


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warning: [V796](https://www.viva64.com/en/w/v796/) It is possible that 'break' statement is missing in switch statement.

(https://github.com/dropbox/lepton/blob/master/src/io/ZlibCompression.cc#L236)