### PR TITLE
make automake not to install test_invariants

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,8 @@ AM_CFLAGS = $(C99_FLAGS) $(CODEC_FLAGS) $(THREAD_FLAGS) $(BILLING_FLAGS) $(BENCH
 
 noinst_LIBRARIES = liblocalzlib.a liblocalmd5.a libtestdriver.a liblocalbrotli.a
 
-bin_PROGRAMS = lepton test_suite/test_invariants
+bin_PROGRAMS = lepton
+noinst_PROGRAMS = test_suite/test_invariants
 
 lepton_LDADD = liblocalmd5.a liblocalbrotli.a $(SYSTEM_DEPENDENCIES_LDFLAGS) -lpthread
 


### PR DESCRIPTION
The program `test_invariants` is only used for testing and installation of this file is not necessary.

This commit removes `test_invariants` from `bin_PROGRAMS` and adds it to `noinst_PROGRAMS` (programs not installed but compiled) instead.