### PR TITLE
Correctly check if CXXFLAGS is set

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -105,7 +105,7 @@ AS_IF([test "x$enable_advanced_jpeg_features" != "xno"], [
 AC_SUBST([CODEC_FLAGS])
 
 
-if test -z $CXXFLAGS; then
+if test -z "$CXXFLAGS"; then
     CXXFLAGS='-O3 -g -DNDEBUG'
 fi
 


### PR DESCRIPTION
Fixes errors like *./configure: line 2617: test: too many arguments* when the `CXXFLAGS` variable is set.

https://travis-ci.org/dropbox/lepton/jobs/530446755#L460