### PR TITLE
[aarch64] make it compile by defining USE_SCALAR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,22 @@ compiler:
 os:
 - linux
 - osx
-script: sh autogen.sh && ./configure CXXFLAGS="-O2 -g -mssse3" --enable-custom-allocator && make liblocalzlib.a && make -j4 && make check && make clean && ./configure CXXFLAGS="-O2 -g -mssse3" --disable-advanced-jpeg-features --enable-custom-allocator && make liblocalzlib.a && make -j4 && make check && make clean && CXXFLAGS="-O2 -mssse3 -DALLOW_3_OR_4_SCALING_FACTOR -DALLOW_FOUR_COLORS" ./configure CXXFLAGS="-O2 -mssse3 -g" && make liblocalzlib.a && make -j4 && make check && make clean && ./configure CXXFLAGS="-O2 -mssse3 -g" --disable-vectorization --enable-custom-allocator  && make liblocalzlib.a && make -j4 && make check && make clean && ./configure CXXFLAGS="-O2 -mssse3 -g" --enable-ans-experimental && make liblocalzlib.a && make -j4 && make check
+env:
+  global:
+      - CXX_EXTRA="-mssse3"
+matrix:
+  include:
+    - os: linux
+      arch: arm64
+      compiler: gcc
+      env:
+       - CXX_EXTRA=""
+
+    - os: linux
+      arch: arm64
+      compiler: clang
+      env:
+       - CXX_EXTRA=""
+       - CONFIGURE_EXTRA="--disable-native-opt"
+
+script: sh autogen.sh && ./configure CXXFLAGS="-O2 -g $CXX_EXTRA" $CONFIGURE_EXTRA --enable-custom-allocator && make liblocalzlib.a && make -j4 && make check && make clean && ./configure CXXFLAGS="-O2 -g $CXX_EXTRA" $CONFIGURE_EXTRA --disable-advanced-jpeg-features --enable-custom-allocator && make liblocalzlib.a && make -j4 && make check && make clean && CXXFLAGS="-O2 $CXX_EXTRA -DALLOW_3_OR_4_SCALING_FACTOR -DALLOW_FOUR_COLORS" ./configure CXXFLAGS="-O2 $CXX_EXTRA -g" $CONFIGURE_EXTRA && make liblocalzlib.a && make -j4 && make check && make clean && ./configure CXXFLAGS="-O2 $CXX_EXTRA -g" $CONFIGURE_EXTRA --disable-vectorization --enable-custom-allocator  && make liblocalzlib.a && make -j4 && make check && make clean && ./configure CXXFLAGS="-O2 $CXX_EXTRA -g" $CONFIGURE_EXTRA --enable-ans-experimental && make liblocalzlib.a && make -j4 && make check

--- a/configure.ac
+++ b/configure.ac
@@ -31,14 +31,13 @@ AC_SUBST(NODEBUG_CXXFLAGS)
 # Add optimizer flags
 
 AC_ARG_ENABLE([native-opt],
-  [AS_HELP_STRING([--disable-vectorization])])
-AC_ARG_ENABLE([vectorization],
-  [AS_HELP_STRING([--disable-vectorization])])
-
+  [AS_HELP_STRING([--disable-native-opt])])
 ARCH_FLAGS="-march=native"
-AS_IF([test "x$enable_vectorization" = "xno"], [
+AS_IF([test "x$enable_native_opt" = "xno"], [
   ARCH_FLAGS=""])
 
+AC_ARG_ENABLE([vectorization],
+  [AS_HELP_STRING([--disable-vectorization])])
 AS_IF([test "x$enable_vectorization" = "xno"], [
   ARCH_FLAGS="$ARCH_FLAGS -DUSE_SCALAR"])
 AC_SUBST([ARCH_FLAGS])

--- a/src/io/Seccomp.cc
+++ b/src/io/Seccomp.cc
@@ -13,6 +13,8 @@
 #  define ARCH_NR AUDIT_ARCH_I386
 #elif defined(__x86_64__)
 #  define ARCH_NR AUDIT_ARCH_X86_64
+#elif defined(__aarch64__)
+#  define ARCH_NR AUDIT_ARCH_AARCH64
 #elif defined(__arm__)
 /*
  * <linux/audit.h> includes <linux/elf-em.h>, which does not define EM_ARM.

--- a/src/lepton/idct.cc
+++ b/src/lepton/idct.cc
@@ -1,4 +1,8 @@
 /* -*-mode:c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+#ifdef __aarch64__
+#define USE_SCALAR 1
+#endif
+
 #ifndef USE_SCALAR
 #include <immintrin.h>
 #include <tmmintrin.h>

--- a/src/lepton/jpgcoder.cc
+++ b/src/lepton/jpgcoder.cc
@@ -58,6 +58,10 @@ volatile int volatile1024 = 1024;
 
 #endif
 
+#ifdef __aarch64__
+#define USE_SCALAR 1
+#endif
+
 #ifndef USE_SCALAR
 #include <emmintrin.h>
 #include <immintrin.h>
@@ -844,6 +848,7 @@ int app_main( int argc, char** argv )
                            &avx2upgrade);
 #ifndef __AVX2__
 #ifndef __clang__
+#ifndef __aarch64__
 #ifndef _ARCH_PPC        
 #ifndef _WIN32
         if (avx2upgrade &&
@@ -864,6 +869,7 @@ int app_main( int argc, char** argv )
             execvp(command, argv);
             argv[0] = old_command; // exec failed
         }
+#endif
 #endif
 #endif
 #endif

--- a/src/vp8/model/model.cc
+++ b/src/vp8/model/model.cc
@@ -8,6 +8,10 @@
 #include <fstream>
 #include <iostream>
 
+#ifdef __aarch64__
+#define USE_SCALAR 1
+#endif
+
 #ifndef USE_SCALAR
 #include <emmintrin.h>
 #endif

--- a/src/vp8/model/model.hh
+++ b/src/vp8/model/model.hh
@@ -13,6 +13,10 @@
 #include "../util/aligned_block.hh"
 #include "../util/block_based_image.hh"
 
+#ifdef __aarch64__
+#define USE_SCALAR 1
+#endif
+
 #ifndef USE_SCALAR
 #include <tmmintrin.h>
 #include "../util/mm_mullo_epi32.hh"

--- a/src/vp8/model/numeric.hh
+++ b/src/vp8/model/numeric.hh
@@ -9,6 +9,11 @@
 #include <algorithm>
 #include <assert.h>
 #include "../util/memory.hh"
+
+#ifdef __aarch64__
+#define USE_SCALAR 1
+#endif
+
 #ifndef USE_SCALAR
 #include <immintrin.h>
 #include <tmmintrin.h>

--- a/src/vp8/util/block_context.hh
+++ b/src/vp8/util/block_context.hh
@@ -2,6 +2,10 @@
 #define BLOCK_CONTEXT_HH_
 #include "options.hh"
 
+#ifdef __aarch64__
+#define USE_SCALAR 1
+#endif
+
 #ifndef USE_SCALAR
 #include "tmmintrin.h"
 #endif

--- a/src/vp8/util/generic_worker.cc
+++ b/src/vp8/util/generic_worker.cc
@@ -1,5 +1,9 @@
 #include "memory.hh"
 
+#ifdef __aarch64__
+#define USE_SCALAR 1
+#endif
+
 #ifndef USE_SCALAR
 #include <emmintrin.h>
 #endif

--- a/src/vp8/util/memory.cc
+++ b/src/vp8/util/memory.cc
@@ -1,3 +1,7 @@
+#ifdef __aarch64__
+#define USE_SCALAR 1
+#endif
+
 #ifndef USE_SCALAR
 #include <immintrin.h>
 #endif


### PR DESCRIPTION
`make check` passes on a Graviton2 aarch64-linux instance.