### PR TITLE
Fix wild free.

### DIFF
--- a/src/lepton/bitops.cc
+++ b/src/lepton/bitops.cc
@@ -83,7 +83,7 @@ abitwriter::abitwriter( int size , int max_file_size)
     error = false;
     fmem  = true;
     dsize = ( size > 0 ) ? size : adds;
-    data2 = ( unsigned char* ) custom_calloc (dsize);
+    data2 = aligned_alloc(dsize);
     if ( data2 == NULL ) {
         error = true;
         custom_exit(ExitCode::MALLOCED_NULL);
@@ -99,12 +99,14 @@ abitwriter::abitwriter( int size , int max_file_size)
 abitwriter::~abitwriter( void )
 {
 	// free memory if pointer was not given out
-    if ( fmem )	custom_free( data2 );
+    if ( fmem )	aligned_dealloc( data2 );
 }
 
 
 void aligned_dealloc(unsigned char *data) {
     if (!data) return;
+    always_assert(((size_t)(data - 0) & 0xf) == 0);
+    always_assert(data[-1] <= 0x10);
     data -= data[-1];
     custom_free(data);
 }

--- a/src/lepton/bitops.hh
+++ b/src/lepton/bitops.hh
@@ -56,6 +56,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../io/ioutil.hh"
 #include "../vp8/util/vpx_config.hh"
 
+extern void aligned_dealloc(unsigned char*);
+extern unsigned char * aligned_alloc(size_t);
+
 /* -----------------------------------------------
 	class to write arrays bitwise
 	----------------------------------------------- */
@@ -129,7 +132,7 @@ public:
                 adds <<= 1;
             }
             int new_size = dsize + adds;
-            unsigned char * tmp = (unsigned char*)custom_malloc(new_size);
+            unsigned char * tmp = aligned_alloc(new_size);
             if ( tmp == NULL ) {
                 error = true;
                 custom_exit(ExitCode::MALLOCED_NULL);
@@ -137,7 +140,7 @@ public:
             }
             memset(tmp + dsize, 0, adds);
             memcpy(tmp, data2, dsize);
-            custom_free(data2);
+            aligned_dealloc(data2);
             data2 = tmp;
             dsize = new_size;
         }
@@ -357,8 +360,6 @@ private:
 /* -----------------------------------------------
 	class to write arrays bytewise
 	----------------------------------------------- */
-extern void aligned_dealloc(unsigned char*);
-extern unsigned char * aligned_alloc(size_t);
 
 class abytewriter
 {

--- a/src/lepton/jpgcoder.cc
+++ b/src/lepton/jpgcoder.cc
@@ -4878,7 +4878,7 @@ bool rebuild_header_jpg( void )
     }
 
     // replace current header with the new one
-    custom_free( hdrdata );
+    aligned_dealloc( hdrdata );
     hdrdata = hdrw->getptr_aligned();
     hdrs    = hdrw->getpos();
     delete( hdrw );


### PR DESCRIPTION
`huffdata` is initially allocated using `aligned_dealloc` but can be
replaced with `data2` which is allocated using `custom_calloc`.
This can cause a wild free when `aligned_dealloc(huffdata)` is called.
Fix by replacing allocation sites with aligned_alloc.

Noticed and fixed a similar problem with `hdrdata`.

Fixes #154.